### PR TITLE
[Dfeusse] Quick edit to integration guides

### DIFF
--- a/docs/adding-magicbell-to-your-product.mdx
+++ b/docs/adding-magicbell-to-your-product.mdx
@@ -1,5 +1,5 @@
 ---
-title: Adding MagicBell to your product
+title: Adding MagicBell to Your Product
 subtitle: Learn how to add the MagicBell UI libraries to your product
 ---
 

--- a/docs/browser/changing-default-font.mdx
+++ b/docs/browser/changing-default-font.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to change the default font
+title: How to Change the Default Font
 ---
 
 ## Change the font family

--- a/docs/browser/changing-default-images.mdx
+++ b/docs/browser/changing-default-images.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to change the default images
+title: How to Change the Default Images
 ---
 
 The notification inbox shows [an image](https://assets.magicbell.io/images/empty_inbox.png) when the user has no notifications. To change it set the `images.emptyInboxUrl` key with your image's url when you initialize the inbox. For example:

--- a/docs/browser/new-notification-hook.mdx
+++ b/docs/browser/new-notification-hook.mdx
@@ -1,5 +1,5 @@
 ---
-title: Notify users when a new notification arrives
+title: Notify Users When a New Notification Arrives
 subtitle: Learn how to add a hook to the new notification event
 ---
 

--- a/docs/channels.mdx
+++ b/docs/channels.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to send notifications across channels
+title: How to Send Notifications Across Channels
 ---
 
 <Note>

--- a/docs/email/3rd-party-email-providers.mdx
+++ b/docs/email/3rd-party-email-providers.mdx
@@ -1,5 +1,5 @@
 ---
-title: 3rd party email providers
+title: 3rd Party Email Providers
 ---
 
 MagicBell can deliver email notifications for your users via 3rd party email providers like [SendGrid](https://magicbell.com/docs/email/sendgrid), [Postmark](https://magicbell.com/docs/email/postmark) and [Mailgun](https://magicbell.com/docs/email/mailgun). Please [send us a note](mailto:hello@magicbell.io) to have it set up for your account.

--- a/docs/email/mailgun.mdx
+++ b/docs/email/mailgun.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mailgun integration
+title: Mailgun Integration
 subtitle: How to use Mailgun with MagicBell's API
 ---
 

--- a/docs/email/postmark.mdx
+++ b/docs/email/postmark.mdx
@@ -14,7 +14,7 @@ subtitle: How to use Postmark with MagicBell's API
 
 ### Sending the email
 
-**No additional work is needed to send an email through Postmark**. Now that your account is set up, the default is send emails using Postmark. You can verify an email was sent in Postmark's application. MagicBell also automatically injects notification_id and broadcast_id as metadata into Postmark.
+**No additional work is needed to send an email through Postmark**. Now that your account is set up, the default is send emails using Postmark. You can verify an email was sent in Postmark's Statistics and Activity pages for each server. MagicBell also automatically injects notification_id and broadcast_id as metadata into Postmark.
 
 ### Sending emails with additional or unique content
 

--- a/docs/email/postmark.mdx
+++ b/docs/email/postmark.mdx
@@ -1,5 +1,5 @@
 ---
-title: Postmark integration
+title: Postmark Integration
 subtitle: How to use Postmark with MagicBell's API
 ---
 

--- a/docs/email/sendgrid.mdx
+++ b/docs/email/sendgrid.mdx
@@ -13,7 +13,7 @@ subtitle: How to use SendGrid with MagicBell's API
 
 ### Sending emails
 
-**No additional work is needed to send an email through SendGrid**. Your account is set up after emailing our team the necessary information. Now, emails sent through MagicBell's API will use SendGrid. You can verify your team sent an email in SendGrid's application.
+**No additional work is needed to send an email through SendGrid**. Your account is set up after emailing our team the necessary information. Now, emails sent through MagicBell's API will use SendGrid. You can verify your team sent an email in SendGrid's [activity feed](https://app.sendgrid.com/email_activity).
 
 ### Sending emails with additional or unique content
 

--- a/docs/email/sendgrid.mdx
+++ b/docs/email/sendgrid.mdx
@@ -1,5 +1,5 @@
 ---
-title: SendGrid integration
+title: SendGrid Integration
 subtitle: How to use SendGrid with MagicBell's API
 ---
 

--- a/docs/libraries-api-wrappers.mdx
+++ b/docs/libraries-api-wrappers.mdx
@@ -1,5 +1,5 @@
 ---
-title: API wrappers and libraries
+title: API Wrappers and Libraries
 ---
 
 Apart from our [REST API](/docs/rest-api/reference), we offer API wrappers in several programming languages. If you'd like to see a wrapper in your favorite programming language, please let us know!

--- a/docs/overrides.mdx
+++ b/docs/overrides.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overrides API parameter
+title: Overrides API Parameter
 subtitle: How to control content across channels and providers
 ---
 

--- a/docs/react-native/getting-started.mdx
+++ b/docs/react-native/getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting started with React Native
+title: Getting Started with React Native
 subtitle: Learn how to create a notification inbox for your mobile app
 ---
 

--- a/docs/react-native/implement-mobile-push-notifications.mdx
+++ b/docs/react-native/implement-mobile-push-notifications.mdx
@@ -1,5 +1,5 @@
 ---
-title: Implement mobile push notifications
+title: Implement Mobile Push Notifications
 subtitle: Learn how to send mobile push notifications from your mobile app
 ---
 

--- a/docs/react/changing-default-notification-component.mdx
+++ b/docs/react/changing-default-notification-component.mdx
@@ -1,5 +1,5 @@
 ---
-title: Change the default notification component
+title: Change the Default Notification Component
 subtitle: Learn how to use your own component to render notifications in the notification inbox
 ---
 

--- a/docs/react/identifying-users.mdx
+++ b/docs/react/identifying-users.mdx
@@ -1,5 +1,5 @@
 ---
-title: Identifying users
+title: Identifying Users
 subtitle: Learn how to initialize the notification inbox for a user
 ---
 

--- a/docs/react/localization-internationalization.mdx
+++ b/docs/react/localization-internationalization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Localization and internationalization (i18n)
+title: Localization and Internationalization (i18n)
 ---
 
 MagicBell is available in 3 languages out of the box: English, Spanish and Brazilian Portuguese. English (`en`) is the default one. However, you can also translate the entire UI into any language you want.

--- a/docs/react/play-sound-new-notification.mdx
+++ b/docs/react/play-sound-new-notification.mdx
@@ -1,8 +1,8 @@
 ---
-title: Play a sound when a notification arrives
+title: Play a Sound When a Notification Arrives
 ---
 
-## Quick start
+## Quickstart
 
 You might want to play a sound or show toast when a new notification arrives. To accomplish this, you can define a function and pass it to your `MagicBell` component as the `onNewNotification` property.
 

--- a/docs/react/positioning-floating-notification-inbox.mdx
+++ b/docs/react/positioning-floating-notification-inbox.mdx
@@ -1,5 +1,5 @@
 ---
-title: Change the position of the notification inbox
+title: Change the Position of the Notification Inbox
 subtitle: Learn how to change the default position of the floating notification inbox
 ---
 

--- a/docs/react/render-notifications-sidebar.mdx
+++ b/docs/react/render-notifications-sidebar.mdx
@@ -1,5 +1,5 @@
 ---
-title: Render notifications in a sidebar
+title: Render Notifications in a Sidebar
 subtitle: Learn how to create a notification inbox in a sidebar
 ---
 

--- a/docs/react/setting-notification-click-handler.mdx
+++ b/docs/react/setting-notification-click-handler.mdx
@@ -1,5 +1,5 @@
 ---
-title: Set a custom click handler
+title: Set a Custom Click Handler
 ---
 
 If you create notifications with an `action_url`, this URL will be opened in the same window when a user clicks on the notification. However, you can easily set a custom click handler by setting the `onNotificationClick` property on the `FloatingNotificationInbox` component.

--- a/docs/react/theme-customization.mdx
+++ b/docs/react/theme-customization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Customize the default theme
+title: Customize the Default Theme
 subtitle: Learn how to change the default theme
 ---
 

--- a/docs/rest-api/authentication.mdx
+++ b/docs/rest-api/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: REST API reference
+title: REST API Reference
 subtitle: Learn how to interact with our API
 ---
 

--- a/docs/turn-on-hmac-authentication.mdx
+++ b/docs/turn-on-hmac-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Turn on HMAC authentication
+title: Turn on HMAC Authentication
 ---
 
 This guide will help you turn on HMAC authentication for your MagicBell project. Read the [HMAC entry on the glossary](/docs/glossary#H) for further information about this authentication code.

--- a/docs/whats-next.mdx
+++ b/docs/whats-next.mdx
@@ -1,5 +1,5 @@
 ---
-title: What's next?
+title: What's Next?
 ---
 
 You’re just getting started with MagicBell, but there’s so much more to explore! Here are some articles you might find interesting:


### PR DESCRIPTION
## Change description

- Changed h1 capitalization pattern so every word is capitalized instead of just the first. Example: from 'Postmark integration' to 'Postmark Integration'
- Quick edit to provider guides explicitly stating history can be checked in SendGrid, Postmark, etc

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
