### PR TITLE
fix: rename invalid dom properties to their correct name

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -19,7 +19,7 @@ We updated the design [of our documentation](https://magicbell.com/docs) to matc
 ### Expanded GraphQL endpoint
 The newly released [GraphQL endpoint](https://magicbell.com/docs/graphql-api/reference) can now fetch users.
 
-### Our first podcast 
+### Our first podcast
 Our team obviously thinks a lot about notifications. We also chat quite a bit interally about tech in general though. Our team has a special affinity for the reading classic fiction, the latest nonfiction, and the importance of writing. We decided to make some conversations widely available to everyone. Let us know what you think of [episode 1](https://open.spotify.com/show/57folJd7V78QZMIIqv762R)!
 
 ## October 25, 2021
@@ -36,7 +36,7 @@ Our team obviously thinks a lot about notifications. We also chat quite a bit in
 ### Ping email provider
 When you want complete control over email rendering and content, [Ping is a great option](https://magicbell.com/docs/email/ping). A few customers have already adopted this feature and have been very happy with the result.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/I7Ej9oBUhCY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/I7Ej9oBUhCY" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 ## October 11, 2021
 

--- a/docs/email/ping.mdx
+++ b/docs/email/ping.mdx
@@ -7,4 +7,4 @@ If you prefer to set up email in your codebase to have full control when renderi
 
 'Ping' allows you to receive a webhook when MagicBell recommends sending an email based on [MagicBell's smart functionality](https://magicbell.com/docs/smart-notifications). You're getting the benefits of MagicBell, yet have complete control over every email. [Watch a demo to learn more!](https://www.youtube.com/watch?v=I7Ej9oBUhCY)
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/I7Ej9oBUhCY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/I7Ej9oBUhCY" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -47,7 +47,7 @@ Whether you are using MagicBell's inbox or building your UI, our SDKs take care 
 <a href="https://www.youtube.com/watch?v=oLkWQfVYjgw&t=1s">Watch a quick demo</a> and refer to <a href="https://magicbell.com/docs/channels">our guides</a> to learn more!
 </strong>
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/oLkWQfVYjgw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/oLkWQfVYjgw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 ## Try MagicBell
 

--- a/docs/smart-notifications.mdx
+++ b/docs/smart-notifications.mdx
@@ -1,6 +1,6 @@
 ---
 title: Smart Notifications
-subtitle: 
+subtitle:
 ---
 
 <Note>
@@ -11,11 +11,11 @@ subtitle:
 
 It's good practice to avoid sending notifications to all channels at once. Now - you don't have to!
 
-Smart delivery allows you to configure which channels to send notifications to, and when, based on categories and user behavior. 
+Smart delivery allows you to configure which channels to send notifications to, and when, based on categories and user behavior.
 
 For example, let's say you have an 'abandoned_cart' category. You can configure delays, so your application initially sends only an in-app notification. If that notification is not seen after a duration of time you define, you can send an email notification. Now, the user is not overwhelmed with multiple notifications simultaneously across channels. Please write to us, and we can work with you to configure these smart notifications. [Watch a demo to learn more!](https://www.youtube.com/watch?v=P4gPQjs1bnQ)
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/P4gPQjs1bnQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/P4gPQjs1bnQ" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 ## How to configure smart notifications
 


### PR DESCRIPTION
## Change description

> Fix warning for invalid dom properties, also fixes fullscreen is unavailable in demo youtube video

![image](https://user-images.githubusercontent.com/26551780/142048905-1716cd99-fa86-43dc-a707-881a6d3cee09.png)

```
Warning: Invalid DOM property `frameborder`. Did you mean `frameBorder`?
    at iframe
    at MDXCreateElement (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:153:30)
    at wrapper (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:148:25)
    at MDXCreateElement (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:153:30)
    at MDXContent (eval at <anonymous> (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/next-mdx-remote/dist/index.js:83:35), <anonymous>:3:916)
    at MDXProvider (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:138:46)
    at MDXRemote (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/next-mdx-remote/dist/index.js:58:22)
    at article
    at div
    at main
    at div
    at div
    at Content (webpack-internal:///./src/components/layout/Content.tsx:15:3)
    at div
    at div
    at DocPageLayout (webpack-internal:///./src/components/layout/DocPageLayout.tsx:37:3)
    at DocPage (webpack-internal:///./src/components/DocPage.tsx:25:3)
    at index (webpack-internal:///./pages/index.tsx:35:3)
    at MDXProvider (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:138:46)
    at MyApp (webpack-internal:///./pages/_app.tsx:52:3)
    at AppContainer (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/next/dist/server/render.js:293:29)
Warning: Invalid DOM property `allowfullscreen`. Did you mean `allowFullScreen`?
    at iframe
    at MDXCreateElement (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:153:30)
    at wrapper (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:148:25)
    at MDXCreateElement (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:153:30)
    at MDXContent (eval at <anonymous> (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/next-mdx-remote/dist/index.js:83:35), <anonymous>:3:916)
    at MDXProvider (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:138:46)
    at MDXRemote (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/next-mdx-remote/dist/index.js:58:22)
    at article
    at div
    at main
    at div
    at div
    at Content (webpack-internal:///./src/components/layout/Content.tsx:15:3)
    at div
    at div
    at DocPageLayout (webpack-internal:///./src/components/layout/DocPageLayout.tsx:37:3)
    at DocPage (webpack-internal:///./src/components/DocPage.tsx:25:3)
    at index (webpack-internal:///./pages/index.tsx:35:3)
    at MDXProvider (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/@mdx-js/react/dist/cjs.js:138:46)
    at MyApp (webpack-internal:///./pages/_app.tsx:52:3)
    at AppContainer (/Users/pavan/Documents/workspace/magicbell/docs/node_modules/next/dist/server/render.js:293:29)

```

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
