### PR TITLE
feat: add anchors to headings to support deep linking

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -58,7 +58,7 @@ export const getStaticProps: GetStaticProps<{}, { slug: string[] }> = async ({
       mdxOptions: {
         rehypePlugins: [
           [rehypeSlug, {}],
-          [autolinkHeadings, {}],
+          [autolinkHeadings, { behavior: 'wrap' }],
         ],
       },
     });

--- a/pages/graphql-api/reference.tsx
+++ b/pages/graphql-api/reference.tsx
@@ -6,6 +6,8 @@ import { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import { serialize } from 'next-mdx-remote/serialize';
 import path from 'path';
 import React from 'react';
+import autolinkHeadings from 'rehype-autolink-headings';
+import rehypeSlug from 'rehype-slug';
 import DocPage from '../../src/components/DocPage';
 import Schema from '../../src/components/graphql/Schema';
 
@@ -40,7 +42,14 @@ export const getStaticProps: GetStaticProps = async () => {
 
   // @ts-ignore
   const { content, data } = matter(fileContents);
-  const mdxAuthenticationSource = await serialize(content);
+  const mdxAuthenticationSource = await serialize(content, {
+    mdxOptions: {
+      rehypePlugins: [
+        [rehypeSlug, {}],
+        [autolinkHeadings, { behavior: 'wrap' }],
+      ],
+    },
+  });
   return {
     props: {
       mdxAuthenticationSource,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,9 @@ import { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import { serialize } from 'next-mdx-remote/serialize';
 import path from 'path';
 import React from 'react';
+import autolinkHeadings from 'rehype-autolink-headings';
+import rehypeSlug from 'rehype-slug';
 import DocPage from '../src/components/DocPage';
-import HomeChangelog from '../src/components/HomeChangelog';
 
 interface Props {
   metadata?: { [key: string]: any };
@@ -14,11 +15,7 @@ interface Props {
 }
 
 export default function index({ mdxSource, metadata = {} }: Props) {
-  return (
-    <DocPage mdxSource={mdxSource} {...metadata}>
-
-    </DocPage>
-  );
+  return <DocPage mdxSource={mdxSource} {...metadata}></DocPage>;
 }
 
 export const getStaticProps: GetStaticProps = async () => {
@@ -28,6 +25,13 @@ export const getStaticProps: GetStaticProps = async () => {
 
   // @ts-ignore
   const { content, data } = matter(fileContents);
-  const mdxSource = await serialize(content);
+  const mdxSource = await serialize(content, {
+    mdxOptions: {
+      rehypePlugins: [
+        [rehypeSlug, {}],
+        [autolinkHeadings, { behavior: 'wrap' }],
+      ],
+    },
+  });
   return { props: { mdxSource, metadata: data } };
 };

--- a/pages/rest-api/reference.tsx
+++ b/pages/rest-api/reference.tsx
@@ -6,6 +6,8 @@ import { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import { serialize } from 'next-mdx-remote/serialize';
 import path from 'path';
 import React from 'react';
+import autolinkHeadings from 'rehype-autolink-headings';
+import rehypeSlug from 'rehype-slug';
 import DocPage from '../../src/components/DocPage';
 import Document from '../../src/components/openapi/Document';
 
@@ -40,7 +42,14 @@ export const getStaticProps: GetStaticProps = async () => {
 
   // @ts-ignore
   const { content, data } = matter(fileContents);
-  const mdxAuthenticationSource = await serialize(content);
+  const mdxAuthenticationSource = await serialize(content, {
+    mdxOptions: {
+      rehypePlugins: [
+        [rehypeSlug, {}],
+        [autolinkHeadings, { behavior: 'wrap' }],
+      ],
+    },
+  });
   return {
     props: {
       mdxAuthenticationSource,

--- a/src/components/HomeChangelog.tsx
+++ b/src/components/HomeChangelog.tsx
@@ -6,7 +6,7 @@ export default function HomeChangelog() {
   return (
     <section className="mt-8">
       <div className="flex items-center justify-between mb-8">
-        <h2 className="">Latest Updates</h2>
+        <h2>Latest Updates</h2>
       </div>
       <ul className="bg-gray-50 rounded-3xl p-2 sm:p-5 xl:p-6 list-none space-y-0 m-0">
         <ChangelogEntry

--- a/src/components/graphql/Field.tsx
+++ b/src/components/graphql/Field.tsx
@@ -1,5 +1,6 @@
 import { GraphQLField, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import React from 'react';
+import slugify from 'slugify';
 import FieldArguments from './FieldArguments';
 import Headers from './Headers';
 import Request from './Request';
@@ -19,10 +20,13 @@ export default function Field({ field, operation, schema }: Props) {
   const [title, description] = descriptionNode
     ? descriptionNode.replace(/\n+/, ':::').split(':::')
     : ['', ''];
+  const titleSlug = slugify(title, { lower: true, remove: /\"\|\?/ });
 
   return (
     <article id={href} className="py-36 border-t">
-      <h2 className="mt-0">{title}</h2>
+      <h2 className="mt-0" id={titleSlug}>
+        <a href={`#${titleSlug}`}>{title}</a>
+      </h2>
       <p className="text-xs rounded bg-blue-50 px-3 py-2 text-blue-600 uppercase font-mono mb-4 inline-block">
         {operation.name}
       </p>

--- a/src/components/openapi/Operation.tsx
+++ b/src/components/openapi/Operation.tsx
@@ -1,6 +1,7 @@
 import { OpenAPIV3 } from 'openapi-types';
 import { includes } from 'ramda';
 import React from 'react';
+import slugify from 'slugify';
 import HeaderParameters from './HeaderParameters';
 import QueryParameters from './QueryParameters';
 import Request from './Request';
@@ -17,9 +18,13 @@ export default function Operation({ pathKey, operation, method }: Props) {
   if (!operation) return null;
 
   const realTimeEnabled = includes('real-time', operation.tags || []);
+  const titleSlug = slugify(operation.summary || '', { lower: true, remove: /\"\|\?/ });
+
   return (
     <article id={operation.operationId} className="py-36 border-t">
-      <h2 className="mt-0">{operation.summary} </h2>
+      <h2 className="mt-0" id={titleSlug}>
+        <a href={`#${titleSlug}`}>{operation.summary}</a>
+      </h2>
       {realTimeEnabled ? (
         <p className="text-xs rounded bg-blue-50 px-3 py-2 text-blue-600 uppercase font-mono mb-4 inline-block">
           real-time

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -154,17 +154,17 @@ img.full-mobile {
   margin: 2rem 0;
 }
 
-.mdx-content h2,
-.mdx-content h3 {
+h2,
+h3 {
   scroll-margin-top: 6.5rem;
 }
 
-.mdx-content h2 a,
-.mdx-content h3 a {
+h2 a,
+h3 a {
   color: inherit;
 }
 
-.mdx-content h2 a:hover,
-.mdx-content h3 a:hover {
+h2 a:hover,
+h3 a:hover {
   @apply text-lightPurple;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -153,3 +153,18 @@ em.highlight {
 img.full-mobile {
   margin: 2rem 0;
 }
+
+.mdx-content h2,
+.mdx-content h3 {
+  scroll-margin-top: 6.5rem;
+}
+
+.mdx-content h2 a,
+.mdx-content h3 a {
+  color: inherit;
+}
+
+.mdx-content h2 a:hover,
+.mdx-content h3 a:hover {
+  @apply text-lightPurple;
+}


### PR DESCRIPTION
## Change description

We already had [rehype-autolink-headings](https://github.com/rehypejs/rehype-autolink-headings) and [rehype-slug](https://github.com/rehypejs/rehype-slug) plugin configured which automatically adds links to headings but the option to wrap heading was not provided.  
For what @smeijer described `'wrap'` works best but there are other behaviour options as well `'prepend', 'append', 'before', 'after'` we could go with depending on what we are looking for.

Since headings are now wrapped inside anchor we might have to tweak the heading color a little.


https://user-images.githubusercontent.com/26551780/143649815-5b2189ca-37a6-4ad1-a5a6-3ac5e29c1100.mp4



## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Implements [#37](https://github.com/magicbell-io/docs/issues/37) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
