### PR TITLE
Fix the documentation for sending slack messages

### DIFF
--- a/docs/slack/custom-apps.mdx
+++ b/docs/slack/custom-apps.mdx
@@ -72,6 +72,8 @@ Go to `https://app.magicbell.com/projects/project_id/channels` and ensure that t
 
 Once your account is set up, MagicBell will automatically deliver slack
 notifications through your Slack app, **no additional work is needed**.
+To send a message to a Slack Channel use the Channel's ID as the externalId.
+To send a DM in Slack you can use the user's email address.
 
 <Tabs>
 
@@ -81,8 +83,7 @@ notifications through your Slack app, **no additional work is needed**.
     "title": "Welcome to Example Inc",
     "recipients": [{
       "email": "dan@example.com",
-      "externalId": "AB1234BCA",
-      "slackChannelId": "AB1234BCA"
+      "externalId": "AB1234BCA"
     }],
     "custom_attributes": {
       "name": "Dan",
@@ -104,8 +105,7 @@ curl https://api.magicbell.com/notifications \
       "title": "Welcome to Example Inc",
       "recipients": [{
         "email": "dan@example.com",
-        "externalId": "AB1234BCA",
-        "slackChannelId": "AB1234BCA"
+        "externalId": "AB1234BCA"
       }],
       "custom_attributes": {
         "name": "Dan",


### PR DESCRIPTION
## Change description

Update the documentation regarding sending slack messages. The `slackChannelId` attributes has been removed from users and is not used when sending messages to slack.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
