### PR TITLE
feat: improve cmd+k shortcut alignment, and add ctrl+k alias

### DIFF
--- a/src/components/layout/SearchBoxShortcut.tsx
+++ b/src/components/layout/SearchBoxShortcut.tsx
@@ -14,13 +14,13 @@ export default function SearchBoxShortcut() {
 
   return (
     <div>
-      <span className="hidden sm:block text-gray-400 text-sm leading-5 py-0.5 px-1.5 border border-gray-300 rounded-md w-9">
+      <span className="hidden sm:flex items-center text-gray-400 text-sm leading-5 p-2 border border-gray-300 rounded-md">
         <span className="sr-only">Press </span>
         <kbd className="font-sans">
           <span title="Command">⌘</span>
         </kbd>
         <span className="sr-only"> and </span>
-        <kbd className="font-sans">K</kbd>
+        <kbd className="font-sans ml-1">K</kbd>
         <span className="sr-only"> to search</span>
       </span>
     </div>

--- a/src/components/layout/SearchBoxShortcut.tsx
+++ b/src/components/layout/SearchBoxShortcut.tsx
@@ -3,12 +3,14 @@ import React, { useEffect } from 'react';
 
 export default function SearchBoxShortcut() {
   useEffect(() => {
-    hotkeys('command+K', function (event, handler) {
+    hotkeys('ctrl+k, command+K', function (event, handler) {
       event.preventDefault();
       document.getElementById('search-field')?.focus();
+      return false;
     });
+
     return () => {
-      hotkeys.unbind('command+K');
+      hotkeys.unbind('ctrl+k, command+K');
     };
   }, []);
 


### PR DESCRIPTION
## Change description

- Fixes the alignment of the cmd+k hotkey button
- Adds ctrl+k alias to select search, as non-apple devices don't have a cmd

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
