### PR TITLE
feat: add 'edit this page' link to the page footer

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -13,11 +13,12 @@ import DocPage from '../src/components/DocPage';
 interface Props {
   metadata?: { [key: string]: any };
   mdxSource?: MDXRemoteSerializeResult;
+  editUrl?: string;
 }
 
-export default function DynamicDocument({ mdxSource, metadata }: Props) {
+export default function DynamicDocument({ mdxSource, metadata, editUrl }: Props) {
   if (!metadata) return null;
-  return <DocPage mdxSource={mdxSource} {...metadata} />;
+  return <DocPage mdxSource={mdxSource} editUrl={editUrl} {...metadata} />;
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -48,6 +49,7 @@ export const getStaticProps: GetStaticProps<{}, { slug: string[] }> = async ({
   const filename = slug + '.mdx';
   const docsDirectory = path.join(process.cwd(), 'docs');
   const filePath = path.join(docsDirectory, filename);
+  const editUrl = `https://github.com/magicbell-io/docs/edit/main/docs/${filename}`;
 
   try {
     const fileContents = fs.readFileSync(filePath, 'utf8');
@@ -63,7 +65,7 @@ export const getStaticProps: GetStaticProps<{}, { slug: string[] }> = async ({
       },
     });
 
-    return { props: { mdxSource, metadata: data } };
+    return { props: { mdxSource, metadata: data, editUrl } };
   } catch (err) {
     return { notFound: true };
   }

--- a/src/components/DocPage.tsx
+++ b/src/components/DocPage.tsx
@@ -7,9 +7,11 @@ interface Props {
   subtitle?: string;
   mdxSource?: MDXRemoteSerializeResult;
   children?: JSX.Element | JSX.Element[];
+  editUrl?: string;
+
 }
 
-export default function DocPage({ title, subtitle, mdxSource, children }: Props) {
+export default function DocPage({ title, subtitle, mdxSource, editUrl, children }: Props) {
   const pageTitle = title || 'Docs';
 
   return (
@@ -24,6 +26,10 @@ export default function DocPage({ title, subtitle, mdxSource, children }: Props)
         <p>Loading...</p>
       )}
       <section>{children}</section>
+
+      {editUrl ? <div className="mt-16">
+        <a href={editUrl}>Edit this page</a>
+      </div> : null}
     </DocPageLayout>
   );
 }

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, {ReactNode} from 'react';
 import SearchBar from './SearchBar';
 
 interface Props {
-  children: JSX.Element | JSX.Element[];
+  children: ReactNode
 }
 
 export default function Content({ children }: Props) {

--- a/src/components/layout/DocPageLayout.tsx
+++ b/src/components/layout/DocPageLayout.tsx
@@ -1,7 +1,7 @@
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import path from 'path';
-import React, { useEffect } from 'react';
+import React, {ReactNode, useEffect} from 'react';
 import { useToggle } from 'react-use';
 import sitemap from '../../../lib/sitemap';
 import DesktopMenu from '../menu/DesktopMenu';
@@ -13,7 +13,7 @@ import Header from './Header';
 interface Props {
   title?: string;
   description?: string;
-  children: JSX.Element | JSX.Element[];
+  children: ReactNode;
 }
 
 export default function DocPageLayout({ title = 'Docs', description, children }: Props) {


### PR DESCRIPTION
## Change description

Adds an `edit this page` link to the footer of docs pages that are created by the `[...slug]` route (read from `/docs`). Clicking the link will open the MDX file in edit mode, on GitHub.

![image](https://user-images.githubusercontent.com/1196524/156774317-32f77b56-807e-4620-8d1c-31b4df025cbc.png)


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
