### PR TITLE
feat: ensure text remains visible while fonts are loading

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,6 +4,7 @@
   font-weight: 400;
   src: url('../fonts/HarmoniaSansRegular.woff2') format('woff2'),
     url('../fonts/HarmoniaSansRegular.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -11,6 +12,7 @@
   font-weight: 600;
   src: url('../fonts/HarmoniaSansSemiBold.woff2') format('woff2'),
     url('../fonts/HarmoniaSansSemiBold.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -18,6 +20,7 @@
   font-weight: 600;
   src: url('../fonts/ITCSouvenirDemi.woff2') format('woff2'),
     url('../fonts/ITCSouvenirDemi.woff') format('woff');
+  font-display: swap;
 }
 
 /* Tailwind */


### PR DESCRIPTION
## Change description

This change makes sure that text is visible during webfont load. We can ensure that by adding `font-display: swap` to font CSS

More info
[https://web.dev/font-display/](https://web.dev/font-display/)

# Lighthouse
**Test machine:**
MacBook Pro (16-inch, 2019)
Processor 2.4 GHz 8-Core Intel Core i9
Memory 64 GB 2667 MHz DDR4

Results will vary between different devices and runs


## Before (running on https://www.magicbell.com/docs)
![image](https://user-images.githubusercontent.com/26551780/159106453-6413a27c-7f24-4e06-9b14-162b3770b14a.png)
![image](https://user-images.githubusercontent.com/26551780/159106461-5d11aae4-9302-4b37-a852-8a6be08a75b6.png)


## After (running on vercel preview https://docs-git-chore-ensure-text-remains-visible-d-aeea41-pavanjadhaw.vercel.app/docs)
![image](https://user-images.githubusercontent.com/26551780/159106392-2a877031-b80d-4bc4-99a0-f6dfc6506272.png)
![image](https://user-images.githubusercontent.com/26551780/159106401-87bcbd4d-5ec0-45ce-88d1-50be23501d7a.png)

**Note** : SEO is taking a hit since these are vercel preview deployment and vercel adds blocking directive source so its not crawlable
![image](https://user-images.githubusercontent.com/26551780/159107422-c0ce0f36-b422-41d0-bee9-4dcfbbfca966.png)


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Optimization

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
