### PR TITLE
Adds 'choosing an identifier' doc to sitemap

### DIFF
--- a/sitemap.json
+++ b/sitemap.json
@@ -13,6 +13,10 @@
         "to": "/adding-magicbell-to-your-product"
       },
       {
+        "name": "Choosing a Unique Identifier",
+        "to": "/choosing-an-identifier"
+      },
+      {
         "name": "Sending notifications",
         "to": "/sending-notifications"
       }


### PR DESCRIPTION
## Change description

> Follow up to #82. The new doc isn't rendering likely because it hasn't been added to sitemap.

![Screen Shot 2022-04-19 at 17 05 15](https://user-images.githubusercontent.com/8107071/164035310-d40ed7cc-79a9-43b4-8c68-b0372d1df41d.png)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
