### PR TITLE
Adds 'whats next' to sitemap

### DIFF
--- a/sitemap.json
+++ b/sitemap.json
@@ -19,6 +19,10 @@
       {
         "name": "Sending notifications",
         "to": "/sending-notifications"
+      },
+      {
+        "name": "What's Next",
+        "to": "/whats-next"
       }
     ]
   },


### PR DESCRIPTION
## Change description

> Docs do not render unless added explicitly to the sitemap (see: #88). This PR adds "What's Next" to it.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
