### PR TITLE
End users can't delete notifications using GraphQL

### DIFF
--- a/docs/graphql-api/authentication.mdx
+++ b/docs/graphql-api/authentication.mdx
@@ -51,7 +51,7 @@ API secret.
 ### Other operations
 
 Your users can perform some operations over their notifications (like
-fetch and delete them). All API requests that perform these operations require:
+fetch them). All API requests that perform these operations require:
 
 - the `X-MAGICBELL-API-KEY` header containing your MagicBell project's API key
 - the `X-MAGICBELL-USER-EXTERNAL-ID` header containing the ID of the user performing the request


### PR DESCRIPTION
## Change description

> Your users can perform some operations over their notifications (like fetch and delete them).

Users can't delete notifications using GraphQL.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Close MAG-385

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
