### PR TITLE
Fix broken link

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -449,7 +449,7 @@ this email if you are interested. Android beta coming up next!
 
 ### **Notification preferences beta**
 
-The [6.27.0-beta.1 version of the React package](https://www.npmjs.com/package/@magicbell/magicbell-react/v/6.27.0-beta.1) offers a notification preferences UI. We'd love for you to try it and give us some feedback. If you add categories to your [POST /notifications API](https://developer.magicbell.io/reference#notification-send-api) calls, we'll render the preferences matrix for your users - automagically. You can see it in action on our [Chrome extension for Hacker news](https://chrome.google.com/webstore/detail/hacker-news-notifications/bbkfblhdgiddlkfkipjdhhfoephonoba?hl=en&authuser=0) (which is pretty awesome, by the way).
+The [6.27.0-beta.1 version of the React package](https://www.npmjs.com/package/@magicbell/magicbell-react/v/6.27.0-beta.1) offers a notification preferences UI. We'd love for you to try it and give us some feedback. If you add categories to your [POST /create-notification API](/docs/rest-api/reference#create-notification) calls, we'll render the preferences matrix for your users - automagically. You can see it in action on our [Chrome extension for Hacker news](https://chrome.google.com/webstore/detail/hacker-news-notifications/bbkfblhdgiddlkfkipjdhhfoephonoba?hl=en&authuser=0) (which is pretty awesome, by the way).
 
 ![https://downloads.intercomcdn.com/i/o/316735864/a0a69ef592ef9ebfb584254a/image.png](https://downloads.intercomcdn.com/i/o/316735864/a0a69ef592ef9ebfb584254a/image.png)
 

--- a/docs/react/changing-default-notification-component.mdx
+++ b/docs/react/changing-default-notification-component.mdx
@@ -87,4 +87,4 @@ export default function CustomNotification(notification) {
 }
 ```
 
-Please refer to our [theming guide](/react/theme-customization) for a complete description of the theme context.
+Please refer to our [theming guide](/docs/react/theme-customization) for a complete description of the theme context.


### PR DESCRIPTION
## Change description

> The /reference link is mentioned multiple times. 
> 
> On the [changelog](https://www.magicbell.com/docs/changelog), the link behind: "POST /notifications API"
>
> The theme-customization link is mentioned at the "[changing default notification component](https://www.magicbell.com/docs/react/changing-default-notification-component)" under "theming guide"

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://linear.app/magicbell-marketing/issue/MAG-196/fix-broken-links

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
