### PR TITLE
fix: handle search results that don't have a content prop

### DIFF
--- a/src/components/layout/SearchHit.tsx
+++ b/src/components/layout/SearchHit.tsx
@@ -26,11 +26,11 @@ export default function SearchHit({ hit }: Props) {
       <article className="px-8 py-4 text-white hover:bg-gray-700 cursor-pointer">
         <p
           className="m-0"
-          dangerouslySetInnerHTML={{ __html: _highlightResult?.title.value || '' }}
+          dangerouslySetInnerHTML={{ __html: _highlightResult?.title?.value || '' }}
         />
         <div
           className="m-0 text-gray-400 truncate text-sm"
-          dangerouslySetInnerHTML={{ __html: _highlightResult?.content.value || '' }}
+          dangerouslySetInnerHTML={{ __html: _highlightResult?.content?.value || '' }}
         />
       </article>
     </Link>

--- a/src/components/layout/SearchHit.tsx
+++ b/src/components/layout/SearchHit.tsx
@@ -8,8 +8,8 @@ interface Props {
     content: string;
     slug: string;
     _highlightResult?: {
-      title: { value: string };
-      content: { value: string };
+      title?: { value?: string };
+      content?: { value?: string };
     };
     _snippetResult?: Record<string, unknown> | undefined;
     _distinctSeqID?: number | undefined;

--- a/src/components/layout/SearchHit.tsx
+++ b/src/components/layout/SearchHit.tsx
@@ -20,17 +20,16 @@ export default function SearchHit({ hit }: Props) {
   if (!hit) return null;
 
   const { _highlightResult, slug } = hit;
+  const { title, content } = _highlightResult || {};
 
+  if (!title && !content) return null;
   return (
     <Link href={slug} passHref>
       <article className="px-8 py-4 text-white hover:bg-gray-700 cursor-pointer">
-        <p
-          className="m-0"
-          dangerouslySetInnerHTML={{ __html: _highlightResult?.title?.value || '' }}
-        />
+        <p className="m-0" dangerouslySetInnerHTML={{ __html: title?.value || '' }} />
         <div
           className="m-0 text-gray-400 truncate text-sm"
-          dangerouslySetInnerHTML={{ __html: _highlightResult?.content?.value || '' }}
+          dangerouslySetInnerHTML={{ __html: content?.value || '' }}
         />
       </article>
     </Link>


### PR DESCRIPTION
Search hits that have no content break error out.

![image](https://user-images.githubusercontent.com/1854377/173666089-cb293223-3acf-4c6c-a0ec-74d306730122.png)

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
