### PR TITLE
Fix "broken" links to GraphQL API

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -307,7 +307,7 @@ documents, interests, etc. An example is below.
 ### New GraphQL endpoint
 
 You can now use GraphQL to fetch notifications. It is available at
-https://api.magicbell.com/graphql. If you use a client like
+`https://api.magicbell.com/graphql`. If you use a client like
 [Insomnia](https://insomnia.rest/) or Postman you will be able to see the schema
 documentation. An example is below.
 

--- a/docs/graphql-api/overview.mdx
+++ b/docs/graphql-api/overview.mdx
@@ -7,7 +7,7 @@ The MagicBell GraphQL API enables you to create precise and flexible queries,
 aggregate data, and type data. You might find it very useful for implementing
 your notification system.
 
-All API access is over HTTPS, and accessed from https://api.magicbell.com/graphql.
+All API access is over HTTPS, and accessed from `https://api.magicbell.com/graphql`.
 
 You can perform introspection against the API directly or visit
 [MagicBell's Postman workspace](https://www.postman.com/magicbell-api/workspace/magicbell)


### PR DESCRIPTION
## Change description

> Links to `https://api.magicbell.com/graphql` raise issues in site health check tools. This PR removes links to the endpoint.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Related issues

> Fix [MAG-592](MAG-592)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
