### PR TITLE
Add a section to explain how sending notifications to subscribers work

### DIFF
--- a/docs/topics.mdx
+++ b/docs/topics.mdx
@@ -47,6 +47,33 @@ Subscriptions allows users to subscribe to and unsubscribe from specific topics.
 1. Jane then sees that `pull-request-1234` is being handled by one of their peers and, due to the constant back and forth, decides they no longer want to be notified about this.
 1. Jane unsubscribes from `pull-request-1234` and stops receiving notifications for that pull request, but will continue to be notified of others.
 
+## Sending notifications for a topic
+
+When creating a notification, you **HAVE TO** set the topic in the `notification.topic` parameter. Along with the topic you also need to add a special recipient. The
+`{ "topic": { "subscribers": true } }` recipient can be used on it's own or along with other recipients. If this specific recipient is not specified the notification
+will only be sent to the supplied recipients.
+
+```json hideHeader
+{
+  "notification": {
+    "title": "@unamashana please review this PR",
+    "recipients": [
+      {
+        "email": "hana@magicbell.io",
+        "external_id": "00001"
+      },
+      {
+        "topic": {
+          "subscribers": true
+        }
+      }
+    ],
+    "topic": "pull-request-123",
+    "category": "comment"
+  }
+}
+```
+
 ### How this all works
 
 1. When a user subscribes to a topic in your app, a subscription record is created with the status `subscribed`. You can update subscription status using either our [REST API](/docs/rest-api/reference#update-topic-subscription) or [GraphQL API](/docs/graphql-api/reference#update-a-user's-subscription-status-to-a-topic).

--- a/docs/topics.mdx
+++ b/docs/topics.mdx
@@ -30,28 +30,9 @@ the notifications should be created with the topic `pull-request-123`
 }
 ```
 
-## Fetching notifications for a topic
+### Creating notifications for subscribers
 
-Topics help with fetching all notifications for a specific entity in your system.
-For example, you may want to show all notifications about a specific order in your UI.
-You can use our Rest API or GraphQL endpoint to fetch all notifications for a topic by supplying the topic query param.
-You can also mark all notifications for a topic `read` in one API call.
-
-## Subscriptions
-
-Subscriptions allows users to subscribe to and unsubscribe from specific topics. Continuing with our GitHub example:
-
-1. Jane would like to receive all notifications related to comments on pull requests.
-1. Jane subscribes to the topic `pull-request`.
-1. When a notification is sent in MagicBell with any topic for which `pull-request` is a substring (e.g., `pull-request-1234` or `pull-request.1234`) of the topic, Jane will be notified.
-1. Jane then sees that `pull-request-1234` is being handled by one of their peers and, due to the constant back and forth, decides they no longer want to be notified about this.
-1. Jane unsubscribes from `pull-request-1234` and stops receiving notifications for that pull request, but will continue to be notified of others.
-
-## Sending notifications for a topic
-
-When creating a notification, you **HAVE TO** set the topic in the `notification.topic` parameter. Along with the topic you also need to add a special recipient. The
-`{ "topic": { "subscribers": true } }` recipient can be used on it's own or along with other recipients. If this specific recipient is not specified the notification
-will only be sent to the supplied recipients.
+The `{ "topic": { "subscribers": true } }` recipient can be used to send notifications to [subscribers](/docs/topics#subscriptions). It can be used on its own or along with other recipients. If this recipient is not specified, the notification will only be sent to the designated recipients.
 
 ```json hideHeader
 {
@@ -73,6 +54,23 @@ will only be sent to the supplied recipients.
   }
 }
 ```
+
+## Fetching notifications for a topic
+
+Topics help with fetching all notifications for a specific entity in your system.
+For example, you may want to show all notifications about a specific order in your UI.
+You can use our Rest API or GraphQL endpoint to fetch all notifications for a topic by supplying the topic query param.
+You can also mark all notifications for a topic `read` in one API call.
+
+## Subscriptions
+
+Subscriptions allows users to subscribe to and unsubscribe from specific topics. Continuing with our GitHub example:
+
+1. Jane would like to receive all notifications related to comments on pull requests.
+1. Jane subscribes to the topic `pull-request`.
+1. When a notification is sent in MagicBell with any topic for which `pull-request` is a substring (e.g., `pull-request-1234` or `pull-request.1234`) of the topic, Jane will be notified.
+1. Jane then sees that `pull-request-1234` is being handled by one of their peers and, due to the constant back and forth, decides they no longer want to be notified about this.
+1. Jane unsubscribes from `pull-request-1234` and stops receiving notifications for that pull request, but will continue to be notified of others.
 
 ### How this all works
 


### PR DESCRIPTION
## Change description

This PR adds a section on the topics page to explain how to send notifications to subscribers.

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
