### PR TITLE
Add the descriptions to the Subscription related input types

### DIFF
--- a/docs/graphql-api/reference/schema.graphql
+++ b/docs/graphql-api/reference/schema.graphql
@@ -176,32 +176,57 @@ type Mutation {
 }
 
 input CreateSubscriptionInput {
+  "The subscription label. This is used on the unsubscribe page."
   label: String
+
+  "The subscription slug, used for identification when performing CRUD operations on Topic Subscriptions"
   slug: String
+
+  "The string that should be used to match against notification topics"
   topic: String
 }
 
 input DeleteSubscriptionInput {
+  "The subscription id"
   id: ID
 }
 
 input UpdateSubscriptionInput {
+  "The subscription id"
   id: ID
+
+  "The subscription label. This is used on the unsubscribe page."
   label: String
+
+  "The subscription slug, used for identification when performing CRUD operations on Topic Subscriptions"
   slug: String
+
+  "The string that should be used to match against notification topics"
   topic: String
 }
 
 input DeleteTopicSubscriptionInput {
+  "The user's email address"
   email: String
+
+  "The user's external id"
   externalId: String
+
+  "The identifying subscription slug"
   subscription: String
 }
 
 input UpdateTopicSubscriptionInput {
+  "The user's email address"
   email: String
+
+  "The user's external id"
   externalId: String
+
+  "Whether the user is subscribed/unsubscribed"
   subscribed: Boolean
+
+  "The identifying subscription slug"
   subscription: String
 }
 


### PR DESCRIPTION
## Change description

> This PR adds descriptions to the `Subscription` & `TopicSubscription` related input types.

## Type of change

- [ ] Bug (fixes an issue)
- [x] Enhancement (adds functionality)

## Related issues

> Fix MAG-682

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
