### PR TITLE
chore: point to unpkg instead of assets.magicbell.io

### DIFF
--- a/docs/adding-magicbell-to-your-product.mdx
+++ b/docs/adding-magicbell-to-your-product.mdx
@@ -48,7 +48,7 @@ For example, to display the notifications for Mary, whose email was mary@example
   (function(i,s,o,g,r,a,m) {i['MagicBellObject'] = r;(i[r] =i[r] ||function() {
   (i[r].q = i[r].q || []).push(arguments);}),(i[r].l = 1 * new Date());(a = s.createElement(o)), (
   m = s.getElementsByTagName(o)[0]);a.async = 1;a.src = g;m.parentNode.insertBefore(a, m);
-  })(window,document,'script','https://assets.magicbell.com/magicbell.min.js','magicbell');
+  })(window,document,'script','https://unpkg.com/@magicbell/embeddable/dist/magicbell.min.js','magicbell');
 
   var target = document.getElementById('notifications-inbox');
   var options = {
@@ -64,7 +64,7 @@ For example, to display the notifications for Mary, whose email was mary@example
 ```html title=ESM hideHeader noTopBorderRadius
 <div id="notifications-inbox" />
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   var target = document.getElementById('notifications-inbox');
   var options = {
@@ -73,7 +73,7 @@ For example, to display the notifications for Mary, whose email was mary@example
     height: 500,
   };
 
-  magicbell('render', target, options);
+  renderWidget(target, options);
 </script>
 ```
 
@@ -170,7 +170,7 @@ After grabbing the library, you can import the `renderWidget` function to render
 If you prefer to use the CDN bundle, replace the import statement (line 6) with
 
 ```javascript hideHeader
-import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 ```
 
 ## Angular
@@ -189,7 +189,7 @@ After grabbing the library, you can import the `renderWidget` function to render
 
 ```typescript title=Angular
 import { Component, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
-import { renderWidget } from '@magicbell/embeddable/dist/magicbell.esm.js';
+import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
 @Component({
   selector: 'app-root',
@@ -210,7 +210,7 @@ export class AppComponent implements AfterViewInit {
 If you prefer to use the CDN bundle, replace the import statement (line 2) with
 
 ```javascript hideHeader
-import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 ```
 
 ## Building a custom UI in any framework

--- a/docs/angular.mdx
+++ b/docs/angular.mdx
@@ -41,5 +41,5 @@ export class AppComponent implements AfterViewInit {
 If you prefer to use the CDN bundle, replace the import statement (line 2) with
 
 ```javascript hideHeader
-import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 ```

--- a/docs/browser/changing-default-font.mdx
+++ b/docs/browser/changing-default-font.mdx
@@ -13,7 +13,7 @@ In the following example, we are changing the font to [IBM Plex Sans](https://fo
 
 ```html title=ESM
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   let theme = {
     header: { fontFamily: 'IBM Plex Sans' },
@@ -39,7 +39,7 @@ In the following example, we are changing the font to [IBM Plex Sans](https://fo
     stylesheets,
   };
 
-  magicbell('render', target, options);
+  renderWidget(target, options);
 </script>
 ```
 
@@ -59,7 +59,7 @@ Pass the font size to all elements you want to customize. In the following examp
 ```html title=ESM
 <div id="notifications-inbox" />
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   let theme = {
     header: { fontSize: '13px' },
@@ -78,6 +78,6 @@ Pass the font size to all elements you want to customize. In the following examp
     theme,
   };
 
-  magicbell('render', targetEl, options);
+  renderWidget(targetEl, options);
 </script>
 ```

--- a/docs/browser/changing-default-images.mdx
+++ b/docs/browser/changing-default-images.mdx
@@ -7,7 +7,7 @@ The notification inbox shows [an image](https://assets.magicbell.io/images/empty
 ```html title=ESM
 <div id="notifications-inbox" />
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   let targetEl = document.getElementById('notifications-inbox');
   let options = {
@@ -19,7 +19,7 @@ The notification inbox shows [an image](https://assets.magicbell.io/images/empty
     },
   };
 
-  magicbell('render', targetEl, options);
+  renderWidget(targetEl, options);
 </script>
 ```
 

--- a/docs/browser/new-notification-hook.mdx
+++ b/docs/browser/new-notification-hook.mdx
@@ -12,7 +12,7 @@ The following example shows how to show an alert when a new notification arrives
 ```html title=ESM hideHeader noTopBorderRadius
 <div id="notifications-inbox" />
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   let targetEl = document.getElementById('notifications-inbox');
   let options = {
@@ -25,7 +25,7 @@ The following example shows how to show an alert when a new notification arrives
     },
   };
 
-  magicbell('render', targetEl, options);
+  renderWidget(targetEl, options);
 </script>
 ```
 
@@ -36,7 +36,7 @@ The following example shows how to show an alert when a new notification arrives
   (function(i,s,o,g,r,a,m) {i['MagicBellObject'] = r;(i[r] =i[r] ||function() {
     (i[r].q = i[r].q || []).push(arguments);}),(i[r].l = 1 * new Date());(a = s.createElement(o)), (
     m = s.getElementsByTagName(o)[0]);a.async = 1;a.src = g;m.parentNode.insertBefore(a, m);
-    })(window,document,'script','https://assets.magicbell.io/magicbell.min.js','magicbell');
+    })(window,document,'script','https://unpkg.com/@magicbell/embeddable/dist/magicbell.min.js','magicbell');
 
   var targetEl = document.getElementById('notifications-inbox');
   var options = {

--- a/docs/react/localization-internationalization.mdx
+++ b/docs/react/localization-internationalization.mdx
@@ -50,7 +50,7 @@ export default function Notifications() {
 
 ```html title=HTML hideHeader noTopBorderRadius
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   let targetEl = document.getElementById('notifications-inbox');
   let options = {
@@ -60,7 +60,7 @@ export default function Notifications() {
     locale: 'pt_BR',
   };
 
-  magicbell('render', targetEl, options);
+  renderWidget(targetEl, options);
 </script>
 ```
 
@@ -117,7 +117,7 @@ export default function Notifications() {
 
 ```html title=HTML hideHeader noTopBorderRadius
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   // Your custom locale definition
   let locale = {
@@ -141,7 +141,7 @@ export default function Notifications() {
     locale,
   };
 
-  magicbell('render', targetEl, options);
+  renderWidget(targetEl, options);
 </script>
 ```
 

--- a/docs/react/theme-customization.mdx
+++ b/docs/react/theme-customization.mdx
@@ -59,7 +59,7 @@ export default function Notifications() {
 
 ```html title=HTML hideHeader noTopBorderRadius
 <script type="module">
-  import { renderWidget } from 'https://assets.magicbell.com/magicbell.esm.js';
+  import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 
   // Your custom theme definition
   let theme = {
@@ -76,7 +76,7 @@ export default function Notifications() {
     theme,
   };
 
-  magicbell('render', targetEl, options);
+  renderWidget(targetEl, options);
 </script>
 ```
 

--- a/docs/vue/adding-magicbell-to-your-nuxt-application.mdx
+++ b/docs/vue/adding-magicbell-to-your-nuxt-application.mdx
@@ -31,7 +31,7 @@ export default MagicBellPlugin;
 If you prefer to use the CDN bundle, replace the import statement (line 2) with
 
 ```javascript
-import { renderWidget } from 'https://assets.magicbell.io/magicbell.esm.js';
+import { renderWidget } from 'https://unpkg.com/@magicbell/embeddable';
 ```
 
 After that, you will need to update your `nuxt.config.js` file and add the newly created plugin to the plugin array as well as the plugin to the transpile list. Your config should look like this:


### PR DESCRIPTION
## Change description

We're deprecating `assets.magicbell.io`, and recommend people to use `unpkg` instead. This pull updates all references.

I've also fixed a few bugs, where `magicbell('render', target, options);` was shown instead of `renderWidget(target, options)`.