### PR TITLE
Create 'Subscriptions' doc as its own article

### DIFF
--- a/docs/subscriptions.mdx
+++ b/docs/subscriptions.mdx
@@ -1,0 +1,59 @@
+---
+title: Subscriptions
+subtitle: Learn how to make use of subscriptions
+---
+
+Subscriptions allow users to subscribe to and unsubscribe from specific [topics](/docs/topics). Continuing with our GitHub example:
+
+1. Jane would like to receive all notifications related to comments on pull requests.
+1. Jane subscribes to the topic `pull-request`.
+1. When a notification is sent in MagicBell with any topic for which `pull-request` is a substring (e.g., `pull-request-1234` or `pull-request.1234`) of the topic, Jane will be notified.
+1. Jane then sees that `pull-request-1234` is being handled by one of their peers and, due to the constant back and forth, decides they no longer want to be notified about this.
+1. Jane unsubscribes from `pull-request-1234` and stops receiving notifications for that pull request, but will continue to be notified of others.
+
+## Creating notifications for subscribers
+
+The `{ "topic": { "subscribers": true } }` recipient can be used to send notifications to subscribers. It can be used on its own or along with other recipients. If this recipient is not specified, the notification will only be sent to the designated recipients.
+
+```json hideHeader
+{
+  "notification": {
+    "title": "@unamashana please review this PR",
+    "recipients": [
+      {
+        "email": "hana@magicbell.io",
+        "external_id": "00001"
+      },
+      {
+        "topic": {
+          "subscribers": true
+        }
+      }
+    ],
+    "topic": "pull-request-123",
+    "category": "comment"
+  }
+}
+```
+
+## How this all works
+
+1. When a user subscribes to a topic in your app, a subscription record is created with the status `subscribed`. You can update subscription status using either our [REST API](/docs/rest-api/reference#update-topic-subscription) or [GraphQL API](/docs/graphql-api/reference#update-a-user's-subscription-status-to-a-topic).
+1. Our backend [creates the subscription](/docs/graphql-api/reference#create-subscription).
+1. Whenever a topic is specified in a notification, the user will receive the notification.
+
+## How users can unsubscribe
+
+When sending a notification you can use the `{{ unsubscribe_url }}` merge tag to generate a URL for the specific recipient and the notification's topic — this can be used in [templates](/docs/templates), [email layout](/docs/email-layouts), and in notification content.
+
+As we don't generate unsubscribe URLs when a topic isn't specified for a notification, consider using [control flow](https://shopify.github.io/liquid/tags/control-flow/) to avoid an empty object being rendered in your notification:
+
+```html title=LIQUID noTopBorderRadius
+{% if unsubscribe_url != "" %} Click here to
+<a href="{{ unsubscribe_url }}">unsubscribe</a>. {% endif %}
+```
+
+<Note>
+  When a user unsubscribes from a topic, they will no longer receive notifications for
+  that topic, even if they are a recipient of the notification.
+</Note>

--- a/docs/topics.mdx
+++ b/docs/topics.mdx
@@ -30,66 +30,9 @@ the notifications should be created with the topic `pull-request-123`
 }
 ```
 
-### Creating notifications for subscribers
-
-The `{ "topic": { "subscribers": true } }` recipient can be used to send notifications to [subscribers](/docs/topics#subscriptions). It can be used on its own or along with other recipients. If this recipient is not specified, the notification will only be sent to the designated recipients.
-
-```json hideHeader
-{
-  "notification": {
-    "title": "@unamashana please review this PR",
-    "recipients": [
-      {
-        "email": "hana@magicbell.io",
-        "external_id": "00001"
-      },
-      {
-        "topic": {
-          "subscribers": true
-        }
-      }
-    ],
-    "topic": "pull-request-123",
-    "category": "comment"
-  }
-}
-```
-
 ## Fetching notifications for a topic
 
 Topics help with fetching all notifications for a specific entity in your system.
 For example, you may want to show all notifications about a specific order in your UI.
 You can use our Rest API or GraphQL endpoint to fetch all notifications for a topic by supplying the topic query param.
 You can also mark all notifications for a topic `read` in one API call.
-
-## Subscriptions
-
-Subscriptions allows users to subscribe to and unsubscribe from specific topics. Continuing with our GitHub example:
-
-1. Jane would like to receive all notifications related to comments on pull requests.
-1. Jane subscribes to the topic `pull-request`.
-1. When a notification is sent in MagicBell with any topic for which `pull-request` is a substring (e.g., `pull-request-1234` or `pull-request.1234`) of the topic, Jane will be notified.
-1. Jane then sees that `pull-request-1234` is being handled by one of their peers and, due to the constant back and forth, decides they no longer want to be notified about this.
-1. Jane unsubscribes from `pull-request-1234` and stops receiving notifications for that pull request, but will continue to be notified of others.
-
-### How this all works
-
-1. When a user subscribes to a topic in your app, a subscription record is created with the status `subscribed`. You can update subscription status using either our [REST API](/docs/rest-api/reference#update-topic-subscription) or [GraphQL API](/docs/graphql-api/reference#update-a-user's-subscription-status-to-a-topic).
-1. Our backend [creates the subscription](/docs/graphql-api/reference#create-subscription).
-1. Whenever a topic is specified in a notification, the user will receive the notification.
-
-### How users can unsubscribe
-
-When sending a notification you can use the `{{ unsubscribe_url }}` merge tag to generate a URL for the specific recipient and the notification's topic — this can be used in [templates](/docs/templates), [email layout](/docs/email-layouts), and in notification content.
-
-As we don't generate unsubscribe URLs when a topic isn't specified for a notification, consider using [control flow](https://shopify.github.io/liquid/tags/control-flow/) to avoid an empty object being rendered in your notification:
-
-```html title=LIQUID noTopBorderRadius
-{% if unsubscribe_url != "" %} Click here to
-<a href="{{ unsubscribe_url }}">unsubscribe</a>. {% endif %}
-```
-
-<Note>
-  When a user unsubscribes from a topic, they will no longer receive notifications for
-  that topic, even if they are a recipient of the notification.
-</Note>

--- a/sitemap.json
+++ b/sitemap.json
@@ -276,7 +276,16 @@
       },
       {
         "name": "Topics",
-        "to": "/topics"
+        "children": [
+          {
+            "name": "Overview",
+            "to": "/topics"
+          },
+          {
+            "name": "Subscriptions",
+            "to": "/subscriptions"
+          }
+        ]
       },
       {
         "name": "Smart Delivery",

--- a/sitemap.json
+++ b/sitemap.json
@@ -292,7 +292,7 @@
         "to": "/smart-delivery"
       },
       {
-        "name": "Override content accross channels",
+        "name": "Override content across channels",
         "to": "/overrides"
       },
       {


### PR DESCRIPTION
## Change description

To improve discoverability of features at a glance, Subscription should be its own article rather than included with Topics.

## Type of change

- [x] Bug (fixes an issue)
- [ ] Enhancement (adds functionality)

## Related issues

SUP-162

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
